### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/news_application/news/views.py
+++ b/news_application/news/views.py
@@ -517,7 +517,9 @@ class NewsletterApprovalView(APIView):
                 status=status.HTTP_200_OK
             )
         except Exception as e:
+            import logging
+            logging.exception("Error approving newsletter")
             return Response(
-                {"error": str(e)},
+                {"error": "An internal error has occurred. Please try again later."},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )


### PR DESCRIPTION
Potential fix for [https://github.com/G3rtPB87/G3rtPB87_Dev/security/code-scanning/2](https://github.com/G3rtPB87/G3rtPB87_Dev/security/code-scanning/2)

To fix this problem, error details (the exception message) should not be exposed directly to API users. Instead, log the exception details on the server for debugging, and return only a generic, user-friendly error message in the API response. Specifically, in the `NewsletterApprovalView.post()` method (lines 503-523), edit the `except` block to (a) log the exception using Python's standard logging facilities and (b) return a generic error message such as "An internal error has occurred." You also need to ensure that logging is possible (i.e., import the `logging` module if not already done) and log the exception appropriately.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
